### PR TITLE
Add `then-redis` as a dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
   },
   "author": "Justin Giancola",
   "license": "MIT",
+  "dependencies": {
+    "then-redis": "^1.3.0"
+  },
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.0",
     "ember-cli": "0.2.0",
@@ -32,7 +35,6 @@
     "ember-data": "1.0.0-beta.15",
     "ember-export-application-global": "^1.0.2",
     "redis": "^0.12.1",
-    "then-redis": "^1.3.0"
   },
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
I may have put this in the wrong place.  Right now if you install fresh and you don't have ember-deploy-redis installed you will get errors because this dependency is missing.
