### PR TITLE
Allow configuration for other environments.

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,11 +33,12 @@ function successfullyWroteKey(key) {
 module.exports.postBuild = function(result) {
   var environment = process.env.EMBER_ENV || 'development';
 
-  if (environment !== 'development') {
+  var config = require(configPath);
+
+  if (Object.keys(config).indexOf(environment) === -1){
     return;
   }
-
-  var redisConfig = require(configPath)[environment].store;
+  var redisConfig = config[environment].store;
 
   var projectName = this.project.name();
   var indexKey = projectName + ":__development__";


### PR DESCRIPTION
Added support for other environment configurations.  I am using ember-cli-mirage in development so needed a new environment to configure for running against my backend's development server.

```
// Example `config.js`
module.exports = {
  django: {
    buildEnv: 'django',
    store: {
      type: 'redis',  // this can be omitted because it is the default
      host: 'localhost',
      port: 6379
    },
    assets: {
      // ...
    }
  },

  // other environments
};

// command line
ember build --watch --environment=django

```
