### PR TITLE
Use silent-error Package

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@
 var path = require('path');
 var fs = require('fs');
 var Promise     = require('ember-cli/lib/ext/promise');
-var SilentError = require('ember-cli/lib/errors/silent');
+var SilentError = require('silent-error');
 var redis = require('then-redis');
 var readFile = Promise.denodeify(fs.readFile);
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "author": "Justin Giancola",
   "license": "MIT",
   "dependencies": {
+    "silent-error": "^1.0.0",
     "then-redis": "^1.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
`SilentError` was removed from ember-cli proper in 1.13, we'll have to
include this ourselves now.
